### PR TITLE
Refactor Dockerfile: install glibc compiler and separate package installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.6
+FROM alpine:3.16.2
 
 VOLUME /root/.aws
 VOLUME /project
 WORKDIR /project
 
-RUN apk --no-cache --update add openssl curl groff less mailcap
+RUN apk --no-cache -v --update add openssl curl groff less mailcap
 
 RUN curl -sL -o awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
     && unzip awscliv2.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,38 @@
 FROM alpine:3.16.2
 
-VOLUME /root/.aws
-VOLUME /project
-WORKDIR /project
+ENV GLIBC_VER=2.31-r0
 
-RUN apk --no-cache -v --update add openssl curl groff less mailcap
-
-RUN curl -sL -o awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
+# install glibc compatibility for alpine
+RUN apk --no-cache add \
+        binutils \
+        curl \
+        openssl \
+        groff \
+        less \
+        mailcap \
+        ca-certificates \
+        bash \
+        openssh-client \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && apk add --no-cache \
+        glibc-${GLIBC_VER}.apk \
+        glibc-bin-${GLIBC_VER}.apk \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
     && unzip awscliv2.zip \
-    && ./aws/install
+    && aws/install \
+    && rm -rf \
+        awscliv2.zip \
+        aws \
+        /usr/local/aws-cli/v2/*/dist/aws_completer \
+        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/*/dist/awscli/examples \
+    && apk --no-cache del \
+        binutils \
+    && rm glibc-${GLIBC_VER}.apk \
+    && rm glibc-bin-${GLIBC_VER}.apk \
+    && rm -rf /var/cache/apk/*
 
 RUN curl -sL -o jq-linux64 https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
     && mv jq-linux64 /usr/local/bin/jq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM mesosphere/aws-cli as PKG
+FROM alpine:3.6
 
-RUN apk --no-cache add openssl \
-    && wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
+VOLUME /root/.aws
+VOLUME /project
+WORKDIR /project
+
+RUN apk --no-cache --update add openssl curl groff less mailcap
+
+RUN curl -sL -o awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
+    && unzip awscliv2.zip \
+    && ./aws/install
+
+RUN curl -sL -o jq-linux64 https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
     && mv jq-linux64 /usr/local/bin/jq \
-    && chmod +x /usr/local/bin/jq \
-    && wget -q -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.1/bin/linux/amd64/kubectl \
-    && wget -q -O gomplate https://github.com/hairyhenderson/gomplate/releases/download/v2.4.0/gomplate_linux-amd64-slim \
+    && chmod +x /usr/local/bin/jq
+
+RUN curl -sL -o kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.1/bin/linux/amd64/kubectl \
+    && curl -sL -o gomplate https://github.com/hairyhenderson/gomplate/releases/download/v2.4.0/gomplate_linux-amd64-slim \
     && chmod +x kubectl gomplate \
     && mv kubectl gomplate /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add openssl \
     && wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
     && mv jq-linux64 /usr/local/bin/jq \
     && chmod +x /usr/local/bin/jq \
-    && wget -q -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.0/bin/linux/amd64/kubectl \
+    && wget -q -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.23.1/bin/linux/amd64/kubectl \
     && wget -q -O gomplate https://github.com/hairyhenderson/gomplate/releases/download/v2.4.0/gomplate_linux-amd64-slim \
     && chmod +x kubectl gomplate \
     && mv kubectl gomplate /usr/local/bin


### PR DESCRIPTION
This PR applies many changes to the Dockerfile. There are three main changes:

1. The base image is now the `alpine:3.16.2`;
2. Each package of aws cli, kubectl and jq are installed in different layers;
3. addition of glibc compiler in order to properly install the AWS CLI 2.